### PR TITLE
Fix for neotest on java filetypes

### DIFF
--- a/config/utils/markdown-preview.nix
+++ b/config/utils/markdown-preview.nix
@@ -1,7 +1,7 @@
 {
   plugins.markdown-preview = {
     enable = true;
-    browser = "firefox";
+    browser = "floorp";
     theme = "dark";
   };
   keymaps = [

--- a/config/utils/neotest.nix
+++ b/config/utils/neotest.nix
@@ -49,7 +49,7 @@
         dap = { justMyCode = false },
         }),
         require "neotest-vim-test" {
-        ignore_file_types = { "python", "vim", "lua", "javascript", "typescript" },
+        ignore_file_types = { "python", "java", "vim", "lua", "javascript", "typescript" },
         },
       },
       output = { enabled = true, open_on_run = true },


### PR DESCRIPTION
vim-test was running at the same time as neotest-java, that shouldn't be happening as I want only java to use neotest-java only