### PR TITLE
feat: Add new options for oil.nvim

### DIFF
--- a/config/utils/oil.nix
+++ b/config/utils/oil.nix
@@ -2,10 +2,17 @@
   plugins.oil = {
     enable = true;
     useDefaultKeymaps = true;
+    deleteToTrash = true;
+    viewOptions = {
+      showHidden = true;
+    };
     float = {
+      padding = 2;
+      maxWidth = 0;
+      maxHeight = 0;
       border = "rounded"; # 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by win open
       winOptions = {
-        winblend = 10;
+        winblend = 0;
       };
     };
     preview = {
@@ -27,6 +34,7 @@
       "gs" = "actions.change_sort";
       "gx" = "actions.open_external";
       "g." = "actions.toggle_hidden";
+      "q" = "actions.close";
     };
   };
   keymaps =
@@ -34,7 +42,7 @@
       {
         mode = "n";
         key = "<leader>e";
-        action = ":Oil<CR>";
+        action = ":Oil --float<CR>";
         options = {
           desc = "Open parent directory";
           silent = true;

--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1707255869,
-        "narHash": "sha256-OTWiexMMzL5SMMoK3B2DhHA3NbZKpdpXOoWeTis+3VY=",
+        "lastModified": 1707312238,
+        "narHash": "sha256-grc7yArqgDBuRcMBsjOFD4GfSEYbyCKd/W3y0Gqm9wE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ff57525a641bd9159ce0dd4de7a9ac1cb05794f2",
+        "rev": "2e18333dd2c696241cde0f6aa0632738dff10c15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Enable deleteToTrash option to not permanently delete files. 
Use :Oil --float instead of default to open it as a float.
Add new keymap to close oil with "q".