### PR TITLE
fix: renamed options in toggleterm and catpuccin nixvim

### DIFF
--- a/config/colorschemes/catppuccin.nix
+++ b/config/colorschemes/catppuccin.nix
@@ -2,41 +2,43 @@
   colorschemes = {
     catppuccin = {
       enable = true;
-      background = {
-        light = "macchiato";
-        dark = "mocha";
-      };
-      flavour = "mocha"; # "latte", "mocha", "frappe", "macchiato" or raw lua code
-      disableBold = false;
-      disableItalic = false;
-      disableUnderline = false;
-      transparentBackground = true;
-      integrations = {
-        cmp = true;
-        noice = true;
-        notify = true;
-        neotree = true;
-        harpoon = true;
-        gitsigns = true;
-        which_key = true;
-        illuminate = {
-          enabled = true;
+      settings = {
+        background = {
+          light = "macchiato";
+          dark = "mocha";
         };
-        treesitter = true;
-        treesitter_context = true;
-        telescope.enabled = true;
-        indent_blankline.enabled = true;
-        mini.enabled = true;
-        native_lsp = {
-          enabled = true;
-          inlay_hints = {
-            background = true;
+        flavour = "mocha"; # "latte", "mocha", "frappe", "macchiato" or raw lua code
+        disableBold = false;
+        disableItalic = false;
+        disableUnderline = false;
+        transparentBackground = true;
+        integrations = {
+          cmp = true;
+          noice = true;
+          notify = true;
+          neotree = true;
+          harpoon = true;
+          gitsigns = true;
+          which_key = true;
+          illuminate = {
+            enabled = true;
           };
-          underlines = {
-            errors = ["underline"];
-            hints = ["underline"];
-            information = ["underline"];
-            warnings = ["underline"];
+          treesitter = true;
+          treesitter_context = true;
+          telescope.enabled = true;
+          indent_blankline.enabled = true;
+          mini.enabled = true;
+          native_lsp = {
+            enabled = true;
+            inlay_hints = {
+              background = true;
+            };
+            underlines = {
+              errors = ["underline"];
+              hints = ["underline"];
+              information = ["underline"];
+              warnings = ["underline"];
+            };
           };
         };
       };

--- a/config/utils/toggleterm.nix
+++ b/config/utils/toggleterm.nix
@@ -1,39 +1,41 @@
 {
   plugins.toggleterm = {
     enable = true;
-    size = ''
-      function(term)
+    settings = {
+      size = ''
+        function(term)
         if term.direction == "horizontal" then
           return 15
-      elseif term.direction == "vertical" then
-          return vim.o.columns * 0.4
-        end
-      end
-    '';
-    openMapping = "<A-i>";
-    hideNumbers = true;
-    shadeTerminals = true;
-    startInInsert = true;
-    terminalMappings = true;
-    persistMode = true;
-    insertMappings = true;
-    closeOnExit = true;
-    shell = "zsh";
-    direction = "horizontal"; # 'vertical' | 'horizontal' | 'window' | 'float'
-    autoScroll = true;
-    floatOpts = {
-      border = "single"; # 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by win open
-      width = 80;
-      height = 20;
-      winblend = 0;
-    };
-    winbar = {
-      enabled = true;
-      nameFormatter = ''
-        function(term)
-          return term.name
-        end
+            elseif term.direction == "vertical" then
+            return vim.o.columns * 0.4
+            end
+            end
       '';
+      open_mapping = "<A-i>";
+      hideNumbers = true;
+      shadeTerminals = true;
+      startInInsert = true;
+      terminalMappings = true;
+      persistMode = true;
+      insertMappings = true;
+      closeOnExit = true;
+      shell = "zsh";
+      direction = "horizontal"; # 'vertical' | 'horizontal' | 'window' | 'float'
+      autoScroll = true;
+      floatOpts = {
+        border = "single"; # 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by win open
+        width = 80;
+        height = 20;
+        winblend = 0;
+      };
+      winbar = {
+        enabled = true;
+        nameFormatter = ''
+          function(term)
+          return term.name
+          end
+        '';
+      };
     };
   };
 


### PR DESCRIPTION
small fix to rename the options in the 2 packages to match the current nixvim version