### PR TITLE
fix: builder error

### DIFF
--- a/config/utils/toggleterm.nix
+++ b/config/utils/toggleterm.nix
@@ -4,25 +4,25 @@
     settings = {
       size = ''
         function(term)
-        if term.direction == "horizontal" then
-          return 15
-            elseif term.direction == "vertical" then
+          if term.direction == "horizontal" then
+            return 15
+              elseif term.direction == "vertical" then
             return vim.o.columns * 0.4
-            end
-            end
+          end
+        end
       '';
-      open_mapping = "<A-i>";
-      hideNumbers = true;
-      shadeTerminals = true;
-      startInInsert = true;
-      terminalMappings = true;
-      persistMode = true;
-      insertMappings = true;
-      closeOnExit = true;
+      open_mapping = "[[<A-i>]]";
+      hide_numbers = true;
+      shade_terminals = true;
+      start_in_insert = true;
+      terminal_mappings = true;
+      persist_mode = true;
+      insert_mappings = true;
+      close_on_exit = true;
       shell = "zsh";
       direction = "horizontal"; # 'vertical' | 'horizontal' | 'window' | 'float'
-      autoScroll = true;
-      floatOpts = {
+      auto_scroll = true;
+      float_opts = {
         border = "single"; # 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by win open
         width = 80;
         height = 20;
@@ -30,9 +30,9 @@
       };
       winbar = {
         enabled = true;
-        nameFormatter = ''
+        name_formatter = ''
           function(term)
-          return term.name
+            return term.name
           end
         '';
       };

--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712883908,
-        "narHash": "sha256-icE1IJE9fHcbDfJ0+qWoDdcBXUoZCcIJxME4lMHwvSM=",
+        "lastModified": 1713254108,
+        "narHash": "sha256-0TZIsfDbHG5zibtlw6x0yOp3jkInIGaJ35B7Y4G8Pec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0c9e3aee1000ac2bfb0e5b98c94c946a5d180a9",
+        "rev": "2fd19c8be2551a61c1ddc3d9f86d748f4db94f00",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1713087347,
-        "narHash": "sha256-RpRIJcbAjR3SF6tarvdG0ErN9afifG/zjxNlntRQrw4=",
+        "lastModified": 1713294906,
+        "narHash": "sha256-xJJZdCBzVFpVppaYyUK4lTTNOnbAxrjhodoJL3Oi91E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ad6a08b69528fdaf7e12c90da06f9a34f32d7ea6",
+        "rev": "514a51877df9fe41ffc38c5237e3c4e5327e7607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
error: could not format file
/nix/store/nmkp9qgraazj3vaxsdfawsmisi6wkf07-init.lua: error parsing: error occurred while creating ast: unexpected token `<`. (starting from line 166, character 260 and ending on line 166, character 261). It was due to toggleterm's open_mapping keymapping, nixvim refactored the original way of changing the mapping key, this commit fixes it.