### PR TITLE
Fix Pressing Enter in Alpha Greeter: Correct on_press Function Definitions

### DIFF
--- a/config/ui/alpha.nix
+++ b/config/ui/alpha.nix
@@ -34,7 +34,9 @@
       {
         type = "button";
         val = "  Find File";
-        on_press.raw = "require('telescope.builtin').find_files";
+        on_press = {
+          __raw = "function() require('telescope.builtin').find_files() end";
+        };
         opts = {
           # hl = "comment";
           keymap = [
@@ -60,7 +62,9 @@
       {
         type = "button";
         val = "  New File";
-        on_press.__raw = "function() vim.cmd[[ene]] end";
+        on_press = {
+          __raw = "function() vim.cmd[[ene]] end";
+        };
         opts = {
           # hl = "comment";
           keymap = [
@@ -86,7 +90,9 @@
       {
         type = "button";
         val = "󰈚  Recent Files";
-        on_press.raw = "require('telescope.builtin').oldfiles";
+        on_press = {
+          __raw = "function() require('telescope.builtin').oldfiles() end";
+        };
         opts = {
           # hl = "comment";
           keymap = [
@@ -112,7 +118,9 @@
       {
         type = "button";
         val = "󰈭  Find Word";
-        on_press.raw = "require('telescope.builtin').live_grep";
+        on_press = {
+          __raw = "function() require('telescope.builtin').live_grep() end";
+        };
         opts = {
           # hl = "comment";
           keymap = [
@@ -138,7 +146,9 @@
       {
         type = "button";
         val = "  Restore Session";
-        on_press.raw = "require('persistence').load()";
+        on_press = {
+          __raw = "function() require('persistence').load() end";
+        };
         opts = {
           # hl = "comment";
           keymap = [
@@ -164,7 +174,9 @@
       {
         type = "button";
         val = "  Quit Neovim";
-        on_press.__raw = "function() vim.cmd[[qa]] end";
+        on_press = {
+          __raw = "function() vim.cmd[[qa]] end";
+        };
         opts = {
           # hl = "comment";
           keymap = [


### PR DESCRIPTION
### Summary
This PR fixes an issue with the `on_press` function definitions in the alpha-nvim configuration, which caused an error when pressing Enter in the options of the alpha greeter. The previous implementation resulted in an E5108 error due to `on_press` values being interpreted as strings instead of functions.

### Changes
- Updated the `on_press` values to be properly defined as Lua functions using the `__raw` attribute.
- Ensured that each `on_press` value is correctly formatted as a Lua function.

### Issue
Fixes the E5108 error: "attempt to call a string value" in alpha-nvim, which occurred when pressing Enter in the options of the alpha greeter on Neovim startup.

### Testing
- Verified that the `on_press` functions are now correctly executed without errors.
- Tested the functionality of each button in the alpha greeter to ensure they perform the intended actions.

### Additional Notes
This change ensures that the alpha-nvim configuration is more robust and prevents similar issues in the future, providing a smooth experience when interacting with the alpha greeter options.