### PR TITLE
Feat: move general mappings to which-key v3

### DIFF
--- a/config/bufferlines/bufferline.nix
+++ b/config/bufferlines/bufferline.nix
@@ -4,7 +4,7 @@
       enable = true;
       settings = {
         options = {
-          separatorStyle = "thick"; # “slant”, “padded_slant”, “slope”, “padded_slope”, “thick”, “thin""
+          separatorStyle = "thick"; # “slant”, “padded_slant”, “slope”, “padded_slope”, “thick”, “thin“
           offsets = [
             {
               filetype = "neo-tree";

--- a/config/bufferlines/bufferline.nix
+++ b/config/bufferlines/bufferline.nix
@@ -2,15 +2,19 @@
   plugins = {
     bufferline = {
       enable = true;
-      separatorStyle = "thick"; # “slant”, “padded_slant”, “slope”, “padded_slope”, “thick”, “thin”
-      offsets = [
-        {
-          filetype = "neo-tree";
-          text = "Neo-tree";
-          highlight = "Directory";
-          text_align = "left";
-        }
-      ];
+      settings = {
+        options = {
+          separatorStyle = "thick"; # “slant”, “padded_slant”, “slope”, “padded_slope”, “thick”, “thin""
+          offsets = [
+            {
+              filetype = "neo-tree";
+              text = "Neo-tree";
+              highlight = "Directory";
+              text_align = "left";
+            }
+          ];
+        };
+      };
     };
   };
   keymaps = [

--- a/config/keymaps.nix
+++ b/config/keymaps.nix
@@ -45,68 +45,6 @@
         desc = "Disable Left arrow key";
       };
     }
-
-    # General maps
-    {
-      mode = "n";
-      key = "<leader>f";
-      action = "+find/file";
-    }
-
-    {
-      mode = "n";
-      key = "<leader>s";
-      action = "+search";
-    }
-
-    {
-      mode = "n";
-      key = "<leader>q";
-      action = "+quit/session";
-    }
-
-    {
-      mode = ["n" "v"];
-      key = "<leader>g";
-      action = "+git";
-    }
-
-    {
-      mode = "n";
-      key = "<leader>u";
-      action = "+ui";
-    }
-
-    {
-      mode = "n";
-      key = "<leader>w";
-      action = "+windows";
-    }
-
-    {
-      mode = "n";
-      key = "<leader><Tab>";
-      action = "+tab";
-    }
-
-    {
-      mode = ["n" "v"];
-      key = "<leader>d";
-      action = "+debug";
-    }
-
-    {
-      mode = ["n" "v"];
-      key = "<leader>c";
-      action = "+code";
-    }
-
-    {
-      mode = ["n" "v"];
-      key = "<leader>t";
-      action = "+test";
-    }
-
     # Tabs
     {
       mode = "n";

--- a/config/sets.nix
+++ b/config/sets.nix
@@ -78,7 +78,7 @@
       colorcolumn = "80";
 
       # Reduce which-key timeout to 10ms
-      timeoutlen = 10;
+      timeoutlen = 100;
 
       # Set encoding type
       encoding = "utf-8";

--- a/config/snippets/luasnip.nix
+++ b/config/snippets/luasnip.nix
@@ -1,11 +1,7 @@
-{
-  pkgs,
-  config,
-  ...
-}: {
+{pkgs, ...}: {
   plugins.luasnip = {
     enable = true;
-    extraConfig = {
+    settings = {
       enable_autosnippets = true;
       store_selection_keys = "<Tab>";
     };

--- a/config/utils/whichkey.nix
+++ b/config/utils/whichkey.nix
@@ -1,19 +1,117 @@
 {
-  # TODO: Implement general mappings
   plugins.which-key = {
     enable = true;
-    ignoreMissing = false;
-    icons = {
-      breadcrumb = "»";
-      group = "+";
-      separator = ""; # ➜
-    };
-    # registrations = {
-    #   "<leader>t" = " Terminal";
-    # };
-    window = {
-      border = "none";
-      winblend = 0;
+    settings = {
+      icons = {
+        breadcrumb = "»";
+        group = "+";
+        separator = ""; # ➜
+      };
+      spec = [
+        # Harpoon Configs
+        {
+          __unkeyed-1 = "<leader>h";
+          mode = "n";
+          group = "+harpoon";
+          icon = "󱡁";
+        }
+        {
+          __unkeyed-1 = "<leader>ha";
+          mode = "n";
+          group = "Add file to Harpoon";
+        }
+        {
+          __unkeyed-1 = "<leader>hj";
+          mode = "n";
+          group = "Harpoon File 1";
+        }
+        {
+          __unkeyed-1 = "<leader>hk";
+          mode = "n";
+          group = "Harpoon File 2";
+        }
+        {
+          __unkeyed-1 = "<leader>hl";
+          mode = "n";
+          group = "Harpoon File 3";
+        }
+        {
+          __unkeyed-1 = "<leader>hm";
+          mode = "n";
+          group = "Harpoon File 4";
+        }
+
+        # General Mappings
+        {
+          __unkeyed-1 = "<leader>c";
+          mode = [
+            "n"
+            "v"
+          ];
+          group = "+code";
+        }
+        {
+          __unkeyed-1 = "<leader>d";
+          mode = [
+            "n"
+            "v"
+          ];
+          group = "+debug";
+        }
+        {
+          __unkeyed-1 = "<leader>f";
+          mode = "n";
+          group = "+find/file";
+        }
+
+        {
+          __unkeyed-1 = "<leader>g";
+          mode = [
+            "n"
+            "v"
+          ];
+          group = "+git";
+        }
+
+        {
+          __unkeyed-1 = "<leader>q";
+          mode = "n";
+          group = "+quit/session";
+        }
+
+        {
+          __unkeyed-1 = "<leader>s";
+          mode = "n";
+          group = "+search";
+        }
+        {
+          __unkeyed-1 = "<leader><Tab>";
+          mode = "n";
+          group = "+tab";
+        }
+
+        {
+          __unkeyed-1 = "<leader>t";
+          mode = "n";
+          group = "+test";
+        }
+
+        {
+          __unkeyed-1 = "<leader>u";
+          mode = "n";
+          group = "+ui";
+        }
+
+        {
+          __unkeyed-1 = "<leader>w";
+          mode = "n";
+          group = "+windows";
+        }
+      ];
+      win = {
+        border = "none";
+        wo.winblend = 0;
+      };
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,17 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": [
-          "nixvim",
-          "nuschtosSearch",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixvim",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1721902368,
-        "narHash": "sha256-noQ5SghRPe0jzQEbFQb3fYbV6LZEzr7lIRQoxlU7fyI=",
+        "lastModified": 1722113426,
+        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "cf8c7405479cfde7ea4dc815e195391d2328df10",
+        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
         "type": "github"
       },
       "original": {
@@ -48,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -114,11 +109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1723202784,
+        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
         "type": "github"
       },
       "original": {
@@ -157,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721852138,
-        "narHash": "sha256-JH8N5uoqoVA6erV4O40VtKKHsnfmhvMGbxMNDLtim5o=",
+        "lastModified": 1723399884,
+        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "304a011325b7ac7b8c9950333cd215a7aa146b0e",
+        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
         "type": "github"
       },
       "original": {
@@ -178,11 +173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721719500,
-        "narHash": "sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw=",
+        "lastModified": 1722924007,
+        "narHash": "sha256-+CQDamNwqO33REJLft8c26NbUi2Td083hq6SvAm2xkU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "884f3fe6d9bf056ba0017c132c39c1f0d07d4fec",
+        "rev": "91010a5613ffd7ee23ee9263213157a1c422b705",
         "type": "github"
       },
       "original": {
@@ -193,12 +188,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721782431,
-        "narHash": "sha256-UNDpwjYxNXQet/g3mgRLsQ9zxrbm9j2JEvP4ijF3AWs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4f02464258baaf54992debfd010a7a3662a25536",
-        "type": "github"
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "path": "/nix/store/h60m1fwahjd2mv6gsg77ji3vb4gpj4dk-source",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "type": "path"
       },
       "original": {
         "id": "nixpkgs",
@@ -207,11 +201,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721743106,
-        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
+        "lastModified": 1723175592,
+        "narHash": "sha256-M0xJ3FbDUc4fRZ84dPGx5VvgFsOzds77KiBMW/mMTnI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
+        "rev": "5e0ca22929f3342b19569b21b2f3462f053e497b",
         "type": "github"
       },
       "original": {
@@ -234,11 +228,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1721946885,
-        "narHash": "sha256-b90iLj3d9tLz5/M8dDnhD5j9vAWjpoNn5WhCLnIwK/g=",
+        "lastModified": 1723816538,
+        "narHash": "sha256-h37ltjdifkd7iLtMtBXSBBeYSTuBEKMW6ClFoC7nReQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "47b6c4804f69556dc22aa2a2e64721f216b69090",
+        "rev": "00f32f0430f82c74919c72af84bc95bf5ae434e4",
         "type": "github"
       },
       "original": {
@@ -256,11 +250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721548975,
-        "narHash": "sha256-agCbztdk1f7nCUz03R6xdbivuBRuqubP2RHW+MNuRTg=",
+        "lastModified": 1723367906,
+        "narHash": "sha256-v1qA4WBGDI2uH/TVqRwuXSBP341W681psbzYJ8zrjog=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "551b031e2bc0bcc9584347a8da6312e57169661d",
+        "rev": "6ca2c3ae05a915c160512bd41f6810f456c9b30d",
         "type": "github"
       },
       "original": {
@@ -314,11 +308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721769617,
-        "narHash": "sha256-6Pqa0bi5nV74IZcENKYRToRNM5obo1EQ+3ihtunJ014=",
+        "lastModified": 1723454642,
+        "narHash": "sha256-S0Gvsenh0II7EAaoc9158ZB4vYyuycvMGKGxIbERNAM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
+        "rev": "349de7bc435bdff37785c2466f054ed1766173be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Closes #99
Closes #102 

Went slightly further than expected here:

- Moved general mappings to Which-key v3 (the new re-write)
- updated the flake inputs and fixed the outdated configs for bufferline and luasnip
- Added harpoon top level mapping as a new addition *will happily delete this, i just saw it was missing so added it*
- Fix nvim-surround plugin by changing the timeoutlen

Tested locally using `nix run` all looked good. 