### PR TITLE
Fix: nvim surround timeoutlen

### DIFF
--- a/config/sets.nix
+++ b/config/sets.nix
@@ -78,7 +78,7 @@
       colorcolumn = "80";
 
       # Reduce which-key timeout to 10ms
-      timeoutlen = 10;
+      timeoutlen = 100;
 
       # Set encoding type
       encoding = "utf-8";


### PR DESCRIPTION
fix: raise timeoutlen to 100 to fix plugins like nvim-surround that use two character shortcuts

fixes #102 