### PR TITLE
FIX: Allow tabbing through snippet parameters

### DIFF
--- a/config/completion/cmp.nix
+++ b/config/completion/cmp.nix
@@ -18,19 +18,54 @@
         mapping = {
           __raw = ''
             cmp.mapping.preset.insert({
-            ['<C-j>'] = cmp.mapping.select_next_item(),
-            ['<C-k>'] = cmp.mapping.select_prev_item(),
-            ['<C-e>'] = cmp.mapping.abort(),
+              ['<C-j>'] = cmp.mapping.select_next_item(),
+              ['<C-k>'] = cmp.mapping.select_prev_item(),
+              ['<C-e>'] = cmp.mapping.abort(),
 
-            ['<C-b>'] = cmp.mapping.scroll_docs(-4),
+              ['<C-b>'] = cmp.mapping.scroll_docs(-4),
 
-             ['<C-f>'] = cmp.mapping.scroll_docs(4),
+              ['<C-f>'] = cmp.mapping.scroll_docs(4),
 
-             ['<C-Space>'] = cmp.mapping.complete(),
+              ['<C-Space>'] = cmp.mapping.complete(),
 
-             ['<CR>'] = cmp.mapping.confirm({ select = true }),
+              ['<S-CR>'] = cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Replace, select = true }),
 
-             ['<S-CR>'] = cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Replace, select = true }),
+              -- Taken from https://github.com/hrsh7th/nvim-cmp/wiki/Example-mappings#luasnip
+              -- to stop interference between cmp and luasnip
+
+              ['<CR>'] = cmp.mapping(function(fallback)
+                    if cmp.visible() then
+                        if luasnip.expandable() then
+                            luasnip.expand()
+                        else
+                            cmp.confirm({
+                                select = true,
+                            })
+                        end
+                    else
+                        fallback()
+                    end
+                end),
+
+              ["<Tab>"] = cmp.mapping(function(fallback)
+                if cmp.visible() then
+                  cmp.select_next_item()
+                elseif luasnip.locally_jumpable(1) then
+                  luasnip.jump(1)
+                else
+                  fallback()
+                end
+              end, { "i", "s" }),
+
+              ["<S-Tab>"] = cmp.mapping(function(fallback)
+                if cmp.visible() then
+                  cmp.select_prev_item()
+                elseif luasnip.locally_jumpable(-1) then
+                  luasnip.jump(-1)
+                else
+                  fallback()
+                end
+              end, { "i", "s" }),
             })
           '';
         };
@@ -99,7 +134,7 @@
         Event = "",
         Operator = "",
         TypeParameter = "",
-      } 
+      }
 
     local cmp = require'cmp'
 


### PR DESCRIPTION
fixes: #104 

Update keymaps for <CR>, <Tab> and <S-Tab> so cmp and luasnip don't compete.