### PR TITLE
Allow Neve to be used as a Nixvim module

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,33 @@ However if you'd like to give it a try before installing, <b>nix run github:redy
     <summary><b>INSTALLATION GUIDE</b></summary>
     I'm assuming you already use nix flakes but in case you don't, please check this tutorial to enable them:
 
-[Flakes](https://nixos.wiki/wiki/Flakes)
+1. Go to flake.nix and add Neve.url = "github:redyf/Neve" to your inputs.
+
+2. Run nix flake update, then Neve should be available for installation.
+
+### Option 1: Using [Flakes](https://nixos.wiki/wiki/Flakes) to install Neve as a Nixvim module.
+
+3. Install it by adding the following code to Nixvim configuration:
+
+```nix
+programs.nixvim = {
+  enable = true;
+  imports = [ inputs.Neve.nixvimModule ];
+  # Then configure Nixvim as usual, you might have to lib.mkForce some of the settings
+  colorschemes.catppuccin.enable = lib.mkForce false;
+  colorschemes.nord.enable = true;
+};
+```
+
+4. Rebuild your system and you should be done :
+
+### Option 2: Using [Flakes](https://nixos.wiki/wiki/Flakes) to install Neve as a package
 
 After enabling it, follow the steps below:
 
-1- Go to flake.nix and add Neve.url = "github:redyf/Neve" to your inputs.
+3. Install it by adding `inputs.Neve.packages.${pkgs.system}.default` to your environment.systemPackages or home.packages if you're using home-manager.
 
-2- Run nix flake update, then Neve should be available for installation.
-
-3- Install it by adding `inputs.Neve.packages.${pkgs.system}.default` to your environment.systemPackages or home.packages if you're using home-manager.
-
-4- Rebuild your system and you should be done :
+4. Rebuild your system and you should be done :
 
 </details>
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,10 @@
     let
       config = import ./config; # import the module directly
     in
+    {
+      nixvimModule = config;
+    }
+    // 
     flake-utils.lib.eachDefaultSystem (
       system:
       let


### PR DESCRIPTION
# Context

Currently, Neve is being installed as a package by Nix. While it's easy to install, it forces users to clone the project and make their own configuration.

The goal of this PR is to provide an alternative that allows us to modify Neve's configuration without touching the flake sources directly.

# Example

```nix
programs.nixvim = {
  enable = true;
  imports = [ inputs.Neve.nixvimModule ];
  # Then configure Nixvim as usual, you might have to lib.mkForce some of the settings
  colorschemes.catppuccin.enable = lib.mkForce false;
  colorschemes.nord.enable = true;
};
```
This keeps the default Neve configuration while allowing users to disable the `catppuccin` theme and enabling `Nord`. The code for this is fairly straightforward.

For now, we only use `nixvim` configuration options but you could define your own to allow for some extra configuration