### PR TITLE
fix: fixed jdtls plugin

### DIFF
--- a/config/languages/default.nix
+++ b/config/languages/default.nix
@@ -6,7 +6,7 @@
 {
   imports = [
     ./treesitter-nvim.nix
-    ./nvim-jdtls.nix
+    ./jdtls.nix
     ./nvim-lint.nix
   ];
 
@@ -15,7 +15,7 @@
   };
   config = lib.mkIf config.languages.enable {
     treesitter-nvim.enable = lib.mkDefault true;
-    nvim-jdtls.enable = lib.mkDefault true;
+    jdtls.enable = lib.mkDefault true;
     nvim-lint.enable = lib.mkDefault true;
   };
 }

--- a/config/languages/jdtls.nix
+++ b/config/languages/jdtls.nix
@@ -5,27 +5,28 @@ let
 in
 {
   options = {
-    nvim-jdtls.enable = lib.mkEnableOption "Enable nvim-jdtls module";
+    jdtls.enable = lib.mkEnableOption "Enable jdtls module";
   };
-  config = lib.mkIf config.nvim-jdtls.enable {
-    plugins.nvim-jdtls = {
+  config = lib.mkIf config.jdtls.enable {
+    plugins.jdtls = {
       enable = true;
-      cmd = [
-        "/nix/store/ka32hdd6lnbs1ahndn64p5519381r2vl-jdt-language-server-1.44.0/bin/jdtls"
-      ];
-      # configuration = "/path/to/configuration";
-      data = "~/.cache/jdtls/workspace";
       settings = {
-        java = {
-          signatureHelp = true;
-          completion = true;
-        };
-      };
-      initOptions = {
-        bundles = [
-          "/nix/store/b9ib40q36wxjl4xs5lng263lflz1fsi7-vscode-extension-vscjava-vscode-java-debug-0.49.2023032407/share/vscode/extensions/vscjava.vscode-java-debug/server/com.microsoft.java.debug.plugin-0.44.0.jar"
-          "${javaTestPath}"
+        cmd = [
+          "/nix/store/ka32hdd6lnbs1ahndn64p5519381r2vl-jdt-language-server-1.44.0/bin/jdtls --data ~/.cache/jdtls/workspace"
         ];
+        # configuration = "/path/to/configuration";
+        settings = {
+          java = {
+            signatureHelp = true;
+            completion = true;
+          };
+        };
+        initOptions = {
+          bundles = [
+            "/nix/store/b9ib40q36wxjl4xs5lng263lflz1fsi7-vscode-extension-vscjava-vscode-java-debug-0.49.2023032407/share/vscode/extensions/vscjava.vscode-java-debug/server/com.microsoft.java.debug.plugin-0.44.0.jar"
+            "${javaTestPath}"
+          ];
+        };
       };
     };
   };


### PR DESCRIPTION
nvim-jdtls is renamed to jdtls, and all configs are now moved to plugins.jdtls.settings